### PR TITLE
Added friendly product names for well-known hardware IDs

### DIFF
--- a/src/dinput_backend.cpp
+++ b/src/dinput_backend.cpp
@@ -125,8 +125,19 @@ const GamepadState& DInputBackend::GetState(int slot) const
 	return states_[slot];
 }
 
+/**
+ * Retrieve the backend's short name.
+ *
+ * @return Pointer to a null-terminated C-string with the backend name.
+ */
 const char* DInputBackend::GetName() const { return Name; }
 
+/**
+ * @brief Retrieve a human-friendly display name for the device occupying a slot.
+ *
+ * @param slot Device slot index (valid range: 0..kMaxDevices-1).
+ * @return const char* Null-terminated display name for the device, or `nullptr` if the slot is out of range or no device is present.
+ */
 const char* DInputBackend::GetSlotDisplayName(int slot) const
 {
 	if (slot < 0 || slot >= kMaxDevices) return nullptr;
@@ -135,7 +146,18 @@ const char* DInputBackend::GetSlotDisplayName(int slot) const
 	return GetFriendlyName(it->vendorId, it->productId);
 }
 
-// ── device enumeration ───────────────────────────────────────
+/**
+ * @brief Callback invoked for each DirectInput device during enumeration.
+ *
+ * Marks an already-known device as found or attempts to create and register a new
+ * DeviceInfo for the discovered device. When SetupDevice succeeds, the new device
+ * is appended to the backend's device list and marked as found.
+ *
+ * @param inst Pointer to the enumerated device instance information.
+ * @param ctx  User context passed to the enumerator; expected to be a pointer to
+ *             the DInputBackend instance.
+ * @return BOOL Always returns DIENUM_CONTINUE to continue device enumeration.
+ */
 
 BOOL CALLBACK DInputBackend::EnumCallback(
 	const DIDEVICEINSTANCEW* inst, VOID* ctx)

--- a/src/dinput_backend.cpp
+++ b/src/dinput_backend.cpp
@@ -1,5 +1,6 @@
 #include "dinput_backend.h"
 #include "sony_layout.h"
+#include "usb_names.h"
 #include <algorithm>
 #include <ranges>
 #include <utility>
@@ -125,6 +126,14 @@ const GamepadState& DInputBackend::GetState(int slot) const
 }
 
 const char* DInputBackend::GetName() const { return Name; }
+
+const char* DInputBackend::GetSlotDisplayName(int slot) const
+{
+	if (slot < 0 || slot >= kMaxDevices) return nullptr;
+	const auto it = std::ranges::find_if(devices_, [slot](const DeviceInfo& d) { return d.slot == slot; });
+	if (it == devices_.end()) return nullptr;
+	return GetFriendlyName(it->vendorId, it->productId);
+}
 
 // ── device enumeration ───────────────────────────────────────
 

--- a/src/dinput_backend.h
+++ b/src/dinput_backend.h
@@ -17,6 +17,31 @@ public:
 
 	~DInputBackend() override;
 	void Init(HWND hwnd) override;
+	/**
+	 * Poll connected devices and update internal input states.
+	 */
+	 
+	/**
+	 * Maximum number of input slots supported by this backend.
+	 * @returns The maximum slot count.
+	 */
+	
+	/**
+	 * Retrieve the current gamepad state for a given slot.
+	 * @param slot Index of the input slot to query.
+	 * @returns Reference to the `GamepadState` for the specified slot.
+	 */
+	
+	/**
+	 * Name identifying this input backend.
+	 * @returns Pointer to a null-terminated string with the backend name.
+	 */
+	
+	/**
+	 * Human-readable display name for a specific slot.
+	 * @param slot Index of the input slot to query.
+	 * @returns Pointer to a null-terminated string describing the slot or its assigned device.
+	 */
 	void Poll() override;
 	[[nodiscard]] int GetMaxSlots() const override;
 	[[nodiscard]] const GamepadState& GetState(int slot) const override;

--- a/src/dinput_backend.h
+++ b/src/dinput_backend.h
@@ -21,6 +21,7 @@ public:
 	[[nodiscard]] int GetMaxSlots() const override;
 	[[nodiscard]] const GamepadState& GetState(int slot) const override;
 	[[nodiscard]] const char* GetName() const override;
+	[[nodiscard]] const char* GetSlotDisplayName(int slot) const override;
 
 private:
 	struct DeviceInfo

--- a/src/dinput_backend.h
+++ b/src/dinput_backend.h
@@ -41,6 +41,7 @@ public:
 	 * Human-readable display name for a specific slot.
 	 * @param slot Index of the input slot to query.
 	 * @returns Pointer to a null-terminated string describing the slot or its assigned device.
+	 *          May return nullptr when no slot/device mapping exists or when no name is available.
 	 */
 	void Poll() override;
 	[[nodiscard]] int GetMaxSlots() const override;

--- a/src/gamepad_renderer.cpp
+++ b/src/gamepad_renderer.cpp
@@ -152,12 +152,17 @@ static void DrawSmallButton(ImDrawList* dl, const Layout& L,
 // ── main entry point ─────────────────────────────────────────
 
 void DrawGamepad(ImDrawList* dl, ImVec2 panelPos, ImVec2 panelSize,
-                 const GamepadState& gs, int slotIndex, const char* backendName) {
+                 const GamepadState& gs, int slotIndex, const char* backendName,
+                 const char* displayName) {
     dl->AddRectFilled(panelPos,
         ImVec2(panelPos.x + panelSize.x, panelPos.y + panelSize.y),
         BgDim(), 8.0f);
 
-    auto header = std::format("Player {}  [{}]", slotIndex + 1, backendName);
+    std::string header;
+    if (displayName && displayName[0] != '\0')
+        header = std::format("Player {} - {}  [{}]", slotIndex + 1, displayName, backendName);
+    else
+        header = std::format("Player {}  [{}]", slotIndex + 1, backendName);
     ImVec2 hts = ImGui::CalcTextSize(header.c_str());
     float headerH = hts.y + 10.0f;
     dl->AddText(ImVec2(panelPos.x + 10, panelPos.y + 5),

--- a/src/gamepad_renderer.cpp
+++ b/src/gamepad_renderer.cpp
@@ -149,7 +149,24 @@ static void DrawSmallButton(ImDrawList* dl, const Layout& L,
     dl->AddText(ImVec2(center.x - ts.x * 0.5f, center.y - ts.y * 0.5f), tc, label);
 }
 
-// ── main entry point ─────────────────────────────────────────
+/**
+ * @brief Render a controller panel that visualizes a gamepad's layout and state.
+ *
+ * Renders a framed panel at the given position/size containing a header (built from the player
+ * slot, optional display name, and backend name), a connection-status pill, and a scaled
+ * representation of the controller showing body, D-pad, face buttons, thumbsticks, bumpers,
+ * triggers, and small buttons. When the gamepad is not connected, displays a centered
+ * "No controller detected" message instead of the controls.
+ *
+ * @param dl ImGui draw list to use for low-level drawing operations.
+ * @param panelPos Top-left corner of the panel in screen coordinates.
+ * @param panelSize Width and height of the panel in screen coordinates.
+ * @param gs Current gamepad state (buttons, sticks, triggers, connection).
+ * @param slotIndex Zero-based player slot index used in the header label.
+ * @param backendName Null-terminated string identifying the input backend (shown in header).
+ * @param displayName Optional null-terminated display name for the controller; when non-empty
+ *                    it is included in the header as "Player N - DisplayName  [backend]".
+ */
 
 void DrawGamepad(ImDrawList* dl, ImVec2 panelPos, ImVec2 panelSize,
                  const GamepadState& gs, int slotIndex, const char* backendName,

--- a/src/gamepad_renderer.cpp
+++ b/src/gamepad_renderer.cpp
@@ -182,14 +182,20 @@ void DrawGamepad(ImDrawList* dl, ImVec2 panelPos, ImVec2 panelSize,
         header = std::format("Player {}  [{}]", slotIndex + 1, backendName);
     ImVec2 hts = ImGui::CalcTextSize(header.c_str());
     float headerH = hts.y + 10.0f;
+
+    const char* status = gs.connected ? "Connected" : "Not Connected";
+    ImVec2 sts = ImGui::CalcTextSize(status);
+    const float pillLeft = panelPos.x + panelSize.x - sts.x - 18 - 4;
+    const float headerClipRight = pillLeft;
+    dl->PushClipRect(ImVec2(panelPos.x + 10, panelPos.y),
+                     ImVec2(headerClipRight, panelPos.y + headerH), true);
     dl->AddText(ImVec2(panelPos.x + 10, panelPos.y + 5),
                 gs.connected ? IM_COL32(220, 220, 220, 255)
                              : IM_COL32(100, 100, 100, 255),
                 header.c_str());
+    dl->PopClipRect();
 
     {
-        const char* status = gs.connected ? "Connected" : "Not Connected";
-        ImVec2 sts = ImGui::CalcTextSize(status);
         float px = panelPos.x + panelSize.x - sts.x - 18;
         float py = panelPos.y + 5;
         ImU32 pillCol = gs.connected ? IM_COL32(50, 180, 80, 200)

--- a/src/gamepad_renderer.h
+++ b/src/gamepad_renderer.h
@@ -19,5 +19,6 @@ namespace GamepadRenderer
 	};
 
 	void DrawGamepad(ImDrawList* dl, ImVec2 panelPos, ImVec2 panelSize,
-	                 const GamepadState& gs, int slotIndex, const char* backendName);
+	                 const GamepadState& gs, int slotIndex, const char* backendName,
+	                 const char* displayName = nullptr);
 } // namespace GamepadRenderer

--- a/src/gamepad_renderer.h
+++ b/src/gamepad_renderer.h
@@ -3,7 +3,27 @@
 #include "imgui.h"
 #include <algorithm>
 
-namespace GamepadRenderer
+/**
+	 * Layout for mapping logical gamepad coordinates to screen space.
+	 *
+	 * Encapsulates an origin and separate X/Y scale factors used to transform
+	 * positions and sizes from the layout's logical coordinate system into
+	 * screen coordinates.
+	 */
+	 
+	/**
+	 * Transform a logical point into screen coordinates by applying the layout origin and scaling.
+	 * @param x X coordinate in the layout's logical coordinate space.
+	 * @param y Y coordinate in the layout's logical coordinate space.
+	 * @returns The transformed point in screen coordinates.
+	 */
+	 
+	/**
+	 * Scale a scalar value using the layout's uniform scale (the smaller of sx and sy).
+	 * @param v Value in the layout's logical units.
+	 * @returns The value scaled into screen units.
+	 */
+	namespace GamepadRenderer
 {
 	struct Layout
 	{

--- a/src/hidapi_backend.cpp
+++ b/src/hidapi_backend.cpp
@@ -1,5 +1,6 @@
 #include "hidapi_backend.h"
 #include "sony_layout.h"
+#include "usb_names.h"
 #include <algorithm>
 #include <ranges>
 #include <utility>
@@ -106,6 +107,14 @@ const GamepadState& HidApiBackend::GetState(const int slot) const
 }
 
 const char* HidApiBackend::GetName() const { return Name; }
+
+const char* HidApiBackend::GetSlotDisplayName(int slot) const
+{
+	if (slot < 0 || slot >= kMaxDevices) return nullptr;
+	const auto it = std::ranges::find_if(devices_, [slot](const std::unique_ptr<DeviceInfo>& d) { return d->slot == slot; });
+	if (it == devices_.end()) return nullptr;
+	return GetFriendlyName((*it)->vendorId, (*it)->productId);
+}
 
 // ── device enumeration ───────────────────────────────────────
 

--- a/src/hidapi_backend.cpp
+++ b/src/hidapi_backend.cpp
@@ -106,8 +106,20 @@ const GamepadState& HidApiBackend::GetState(const int slot) const
 	return states_[slot];
 }
 
+/**
+ * @brief Returns the backend's identifier string.
+ *
+ * @return const char* Null-terminated name of this HID backend.
+ */
 const char* HidApiBackend::GetName() const { return Name; }
 
+/**
+ * @brief Retrieve the user-facing display name for a device assigned to a slot.
+ *
+ * @param slot Slot index to query (valid range: 0 to kMaxDevices - 1).
+ * @return const char* Pointer to a friendly name derived from the device's vendor and product IDs,
+ *         or `nullptr` if the slot is out of range or no device is assigned to that slot.
+ */
 const char* HidApiBackend::GetSlotDisplayName(int slot) const
 {
 	if (slot < 0 || slot >= kMaxDevices) return nullptr;
@@ -116,7 +128,14 @@ const char* HidApiBackend::GetSlotDisplayName(int slot) const
 	return GetFriendlyName((*it)->vendorId, (*it)->productId);
 }
 
-// ── device enumeration ───────────────────────────────────────
+/**
+ * @brief Enumerates connected HID devices and synchronizes the backend's device list.
+ *
+ * @details Scans the system for present HID device interfaces, marks previously-known
+ * devices that remain present, attempts to open and initialize newly discovered devices,
+ * and removes (and closes) devices that are no longer present. Updates the internal
+ * devices_ container and associated per-slot state as devices are added or removed.
+ */
 
 void HidApiBackend::EnumerateDevices()
 {

--- a/src/hidapi_backend.h
+++ b/src/hidapi_backend.h
@@ -18,6 +18,39 @@ public:
 	static constexpr int kMaxDevices = 16;
 
 	~HidApiBackend() override;
+	/**
+	 * Poll HID devices, process incoming reports, and update internal gamepad states.
+	 */
+	 
+	/**
+	 * Return the maximum number of device slots supported by this backend.
+	 * @returns The maximum number of slots.
+	 */
+	 
+	/**
+	 * Retrieve the current gamepad state for a given slot.
+	 * @param slot Index of the slot to query; valid range is 0 .. GetMaxSlots()-1.
+	 * @returns Reference to the GamepadState for the specified slot.
+	 */
+	 
+	/**
+	 * Get the backend name identifier.
+	 * @returns Null-terminated string identifying this backend.
+	 */
+	 
+	/**
+	 * Get a human-readable display name for the device assigned to a slot.
+	 * @param slot Index of the slot to query; valid range is 0 .. GetMaxSlots()-1.
+	 * @returns Null-terminated display name for the slot, or an empty string if none.
+	 */
+	 
+	/**
+	 * Per-device runtime information and resources used to manage a HID device.
+	 *
+	 * Contains device path, OS handle and overlapped I/O state, read buffer,
+	 * HID preparsed data and capability descriptors, assigned slot index, flags
+	 * tracking discovery and read state, and the device's vendor/product IDs.
+	 */
 	void Poll() override;
 	[[nodiscard]] int GetMaxSlots() const override;
 	[[nodiscard]] const GamepadState& GetState(int slot) const override;

--- a/src/hidapi_backend.h
+++ b/src/hidapi_backend.h
@@ -41,7 +41,7 @@ public:
 	/**
 	 * Get a human-readable display name for the device assigned to a slot.
 	 * @param slot Index of the slot to query; valid range is 0 .. GetMaxSlots()-1.
-	 * @returns Null-terminated display name for the slot, or an empty string if none.
+	 * @returns A null-terminated display name for the slot, or nullptr when no name is available.
 	 */
 	 
 	/**

--- a/src/hidapi_backend.h
+++ b/src/hidapi_backend.h
@@ -22,6 +22,7 @@ public:
 	[[nodiscard]] int GetMaxSlots() const override;
 	[[nodiscard]] const GamepadState& GetState(int slot) const override;
 	[[nodiscard]] const char* GetName() const override;
+	[[nodiscard]] const char* GetSlotDisplayName(int slot) const override;
 
 private:
 	struct DeviceInfo

--- a/src/input_backend.h
+++ b/src/input_backend.h
@@ -62,5 +62,5 @@ public:
 	[[nodiscard]] virtual int GetMaxSlots() const = 0;
 	[[nodiscard]] virtual const GamepadState& GetState(int slot) const = 0;
 	[[nodiscard]] virtual const char* GetName() const = 0;
-	[[nodiscard]] virtual const char* GetSlotDisplayName(int slot) const { return nullptr; }
+	[[nodiscard]] virtual const char* GetSlotDisplayName([[maybe_unused]] int slot) const { return nullptr; }
 };

--- a/src/input_backend.h
+++ b/src/input_backend.h
@@ -16,4 +16,5 @@ public:
 	[[nodiscard]] virtual int GetMaxSlots() const = 0;
 	[[nodiscard]] virtual const GamepadState& GetState(int slot) const = 0;
 	[[nodiscard]] virtual const char* GetName() const = 0;
+	[[nodiscard]] virtual const char* GetSlotDisplayName(int slot) const { return nullptr; }
 };

--- a/src/input_backend.h
+++ b/src/input_backend.h
@@ -2,6 +2,52 @@
 #include "gamepad_state.h"
 #include <Windows.h>
 
+/**
+ * Abstract interface for input backends that provide per-slot gamepad state.
+ */
+ 
+/**
+ * Virtual destructor to allow proper cleanup of derived implementations.
+ */
+
+/**
+ * Initialize the backend with an optional window handle.
+ * @param hwnd Window handle used for backend initialization (may be ignored).
+ */
+
+/**
+ * Handle a window message.
+ * @param msg The window message identifier.
+ * @param wParam The message wParam.
+ * @param lParam The message lParam.
+ * @returns `true` if the message was handled, `false` otherwise.
+ */
+
+/**
+ * Update the backend's input state for all slots.
+ */
+
+/**
+ * Get the maximum number of input slots supported by this backend.
+ * @returns The maximum number of supported input slots.
+ */
+
+/**
+ * Get the current gamepad state for a specific slot.
+ * @param slot Index of the input slot.
+ * @returns A const reference to the GamepadState for the specified slot.
+ */
+
+/**
+ * Get the name of this backend.
+ * @returns A null-terminated C-string identifying the backend.
+ */
+
+/**
+ * Get a display name for a specific slot, if available.
+ * @param slot Index of the input slot.
+ * @returns A null-terminated C-string containing the slot display name, or `nullptr` if none is available.
+ */
 class IInputBackend
 {
 public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,11 +354,12 @@ int APIENTRY wWinMain(
 						const GamepadState* state;
 						int slotIndex;
 						const char* backendName;
+						const char* displayName;
 					};
 					std::vector<SlotInfo> slots;
 					for (int i = 0; i < b->GetMaxSlots(); ++i)
 						if (b->GetState(i).connected)
-							slots.push_back({&b->GetState(i), i, b->GetName()});
+							slots.push_back({&b->GetState(i), i, b->GetName(), b->GetSlotDisplayName(i)});
 
 					ImDrawList* dl = ImGui::GetWindowDrawList();
 					ImVec2 origin = ImGui::GetCursorScreenPos();
@@ -393,7 +394,7 @@ int APIENTRY wWinMain(
 
 							GamepadRenderer::DrawGamepad(dl, pos, size,
 							                             *slots[i].state, slots[i].slotIndex,
-							                             slots[i].backendName);
+							                             slots[i].backendName, slots[i].displayName);
 						}
 					}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,6 +214,17 @@ static LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	return DefWindowProc(hWnd, msg, wParam, lParam);
 }
 
+/**
+ * @brief Application entry point that initializes subsystems, runs the main event and render loop, and performs cleanup on exit.
+ *
+ * Initializes DPI awareness, registers the main window class, loads persisted preferences, creates the main window and Direct3D/ImGui backends, constructs input backends, and enters the primary message/poll/render loop that drives UI and input visualization. On exit it shuts down ImGui and Direct3D, saves state as needed, and unregisters the window class.
+ *
+ * @param hInstance Handle to the current application instance.
+ * @param hPrevInstance Reserved; typically unused.
+ * @param lpCmdLine Command line for the application as a Unicode string.
+ * @param nCmdShow Controls how the window is to be shown.
+ * @return int `0` on normal exit, non-zero on initialization failure (e.g., Direct3D creation failure).
+ */
 int APIENTRY wWinMain(
 	_In_ HINSTANCE hInstance,
 	_In_opt_ HINSTANCE,

--- a/src/rawinput_backend.cpp
+++ b/src/rawinput_backend.cpp
@@ -86,6 +86,8 @@ const char* RawInputBackend::GetSlotDisplayName(int slot) const
 
 PHIDP_PREPARSED_DATA RawInputBackend::PP(DeviceInfo& d)
 {
+	if (d.preparsedBuf.empty())
+		return nullptr;
 	return reinterpret_cast<PHIDP_PREPARSED_DATA>(d.preparsedBuf.data());
 }
 

--- a/src/rawinput_backend.cpp
+++ b/src/rawinput_backend.cpp
@@ -1,5 +1,6 @@
 #include "rawinput_backend.h"
 #include "sony_layout.h"
+#include "usb_names.h"
 #include <algorithm>
 #include <ranges>
 #include <utility>
@@ -55,6 +56,15 @@ const GamepadState& RawInputBackend::GetState(const int slot) const
 }
 
 const char* RawInputBackend::GetName() const { return Name; }
+
+const char* RawInputBackend::GetSlotDisplayName(int slot) const
+{
+	if (slot < 0 || slot >= kMaxDevices) return nullptr;
+	for (const auto& [h, d] : devices_)
+		if (d.slot == slot)
+			return GetFriendlyName(d.vendorId, d.productId);
+	return nullptr;
+}
 
 // ── private helpers ──────────────────────────────────────────
 

--- a/src/rawinput_backend.cpp
+++ b/src/rawinput_backend.cpp
@@ -55,8 +55,19 @@ const GamepadState& RawInputBackend::GetState(const int slot) const
 	return states_[slot];
 }
 
+/**
+ * @brief Get the backend name.
+ *
+ * @return const char* Pointer to a null-terminated string identifying the backend.
+ */
 const char* RawInputBackend::GetName() const { return Name; }
 
+/**
+ * @brief Retrieves a human-readable display name for the device occupying a slot.
+ *
+ * @param slot Device slot index (0..kMaxDevices-1).
+ * @return const char* Pointer to a null-terminated friendly name for the device in the specified slot, or `nullptr` if the slot is out of range or no device is present.
+ */
 const char* RawInputBackend::GetSlotDisplayName(int slot) const
 {
 	if (slot < 0 || slot >= kMaxDevices) return nullptr;
@@ -66,7 +77,12 @@ const char* RawInputBackend::GetSlotDisplayName(int slot) const
 	return nullptr;
 }
 
-// ── private helpers ──────────────────────────────────────────
+/**
+ * @brief Obtain the device's preparsed HID data as a PHIDP_PREPARSED_DATA pointer.
+ *
+ * @param d DeviceInfo containing the raw preparsed data buffer.
+ * @return PHIDP_PREPARSED_DATA Pointer to the preparsed HID data, or `nullptr` if the device's preparsed buffer is empty.
+ */
 
 PHIDP_PREPARSED_DATA RawInputBackend::PP(DeviceInfo& d)
 {

--- a/src/rawinput_backend.h
+++ b/src/rawinput_backend.h
@@ -16,6 +16,45 @@ public:
 
 	void Init(HWND hwnd) override;
 	bool OnWindowMessage(UINT msg, WPARAM wParam, LPARAM lParam) override;
+	/**
+	 * Poll input backend and update internal per-slot gamepad states.
+	 *
+	 * This performs a single polling pass to process pending input events and refresh
+	 * stored GamepadState for each active slot.
+	 */
+	 
+	/**
+	 * Return the maximum number of device slots supported by this backend.
+	 *
+	 * @returns The maximum number of slots available for gamepad devices.
+	 */
+	 
+	/**
+	 * Return the current GamepadState for a given slot.
+	 *
+	 * @param slot Index of the slot to query (0-based).
+	 * @returns Reference to the stored GamepadState for the specified slot.
+	 */
+	 
+	/**
+	 * Return the backend's human-readable name.
+	 *
+	 * @returns A null-terminated string containing the backend name.
+	 */
+	 
+	/**
+	 * Return the display name for a specific slot.
+	 *
+	 * @param slot Index of the slot to query (0-based).
+	 * @returns A null-terminated string containing the display name for the slot, or an empty string if none.
+	 */
+	 
+	/**
+	 * Information tracked for a single raw input device.
+	 *
+	 * Contains the device handle, cached preparsed HID data and capability structures,
+	 * the assigned slot index, and vendor/product identifiers.
+	 */
 	void Poll() override;
 	[[nodiscard]] int GetMaxSlots() const override;
 	[[nodiscard]] const GamepadState& GetState(int slot) const override;

--- a/src/rawinput_backend.h
+++ b/src/rawinput_backend.h
@@ -46,7 +46,8 @@ public:
 	 * Return the display name for a specific slot.
 	 *
 	 * @param slot Index of the slot to query (0-based).
-	 * @returns A null-terminated string containing the display name for the slot, or an empty string if none.
+	 * @returns A null-terminated string on success; nullptr when no display name is available.
+	 *          The returned pointer is valid for the lifetime of this backend; caller does not take ownership.
 	 */
 	 
 	/**

--- a/src/rawinput_backend.h
+++ b/src/rawinput_backend.h
@@ -20,6 +20,7 @@ public:
 	[[nodiscard]] int GetMaxSlots() const override;
 	[[nodiscard]] const GamepadState& GetState(int slot) const override;
 	[[nodiscard]] const char* GetName() const override;
+	[[nodiscard]] const char* GetSlotDisplayName(int slot) const override;
 
 private:
 	struct DeviceInfo

--- a/src/usb_names.cpp
+++ b/src/usb_names.cpp
@@ -1,0 +1,78 @@
+#include "usb_names.h"
+#include <algorithm>
+#include <utility>
+
+namespace {
+
+struct Entry
+{
+	uint16_t vid;
+	uint16_t pid;
+	const char* name;
+};
+
+// Microsoft (045e) Xbox-related devices and Sony (054c) gamepads from usb.ids / sony_layout.
+// Sorted by (vid, pid) for binary search.
+static constexpr Entry kTable[] = {
+	// Microsoft Corp. (045e) - Xbox
+	{0x045e, 0x0202, "Xbox Controller"},
+	{0x045e, 0x0280, "Xbox Memory Unit (8MB)"},
+	{0x045e, 0x0283, "Xbox Communicator"},
+	{0x045e, 0x0284, "Xbox DVD Playback Kit"},
+	{0x045e, 0x0285, "Xbox Controller S"},
+	{0x045e, 0x0288, "Xbox Controller S Hub"},
+	{0x045e, 0x0289, "Xbox Controller S"},
+	{0x045e, 0x028b, "Xbox360 DVD Emulator"},
+	{0x045e, 0x028d, "Xbox360 Memory Unit 64MB"},
+	{0x045e, 0x028e, "Xbox360 Controller"},
+	{0x045e, 0x028f, "Xbox360 Wireless Controller via Plug & Charge Cable"},
+	{0x045e, 0x0290, "Xbox360 Performance Pipe (PIX)"},
+	{0x045e, 0x0291, "Xbox 360 Wireless Receiver for Windows"},
+	{0x045e, 0x0292, "Xbox360 Wireless Networking Adapter"},
+	{0x045e, 0x029c, "Xbox360 HD-DVD Drive"},
+	{0x045e, 0x029d, "Xbox360 HD-DVD Drive"},
+	{0x045e, 0x029e, "Xbox360 HD-DVD Memory Unit"},
+	{0x045e, 0x02a0, "Xbox360 Big Button IR"},
+	{0x045e, 0x02a8, "Xbox360 Wireless N Networking Adapter [Atheros AR7010+AR9280]"},
+	{0x045e, 0x02ad, "Xbox NUI Audio"},
+	{0x045e, 0x02ae, "Xbox NUI Camera"},
+	{0x045e, 0x02b0, "Xbox NUI Motor"},
+	{0x045e, 0x02b6, "Xbox360 Bluetooth Wireless Headset"},
+	{0x045e, 0x02bb, "Kinect Audio"},
+	{0x045e, 0x02be, "Kinect for Windows NUI Audio"},
+	{0x045e, 0x02bf, "Kinect for Windows NUI Camera"},
+	{0x045e, 0x02c2, "Kinect for Windows NUI Motor"},
+	{0x045e, 0x02d1, "Xbox One Controller"},
+	{0x045e, 0x02d5, "Xbox One Digital TV Tuner"},
+	{0x045e, 0x02dd, "Xbox One Controller (Firmware 2015)"},
+	{0x045e, 0x02e0, "Xbox One Wireless Controller"},
+	{0x045e, 0x02e3, "Xbox One Elite Controller"},
+	{0x045e, 0x02e6, "Wireless XBox Controller Dongle"},
+	{0x045e, 0x02ea, "Xbox One S Controller"},
+	{0x045e, 0x02f3, "Xbox One Chatpad"},
+	{0x045e, 0x02fd, "Xbox One S Controller [Bluetooth]"},
+	{0x045e, 0x02fe, "Xbox Wireless Adapter for Windows"},
+	{0x045e, 0x02ff, "Xbox Wireless Controller"},
+	{0x045e, 0x0b00, "Xbox Elite Series 2 Controller (model 1797)"},
+	{0x045e, 0x0b12, "Xbox Controller"},
+	// Sony (054c) - DualShock / DualSense
+	{0x054c, 0x05c4, "DualShock 4"},
+	{0x054c, 0x09cc, "DualShock 4 (v2 / Pro/Slim)"},
+	{0x054c, 0x0ce6, "DualSense"},
+	{0x054c, 0x0df2, "DualSense Edge"},
+};
+
+} // namespace
+
+const char* GetFriendlyName(uint16_t vid, uint16_t pid)
+{
+	const auto it = std::lower_bound(std::begin(kTable), std::end(kTable),
+		std::pair{vid, pid},
+		[](const Entry& e, const std::pair<uint16_t, uint16_t>& vp) {
+			if (e.vid != vp.first) return e.vid < vp.first;
+			return e.pid < vp.second;
+		});
+	if (it != std::end(kTable) && it->vid == vid && it->pid == pid)
+		return it->name;
+	return nullptr;
+}

--- a/src/usb_names.cpp
+++ b/src/usb_names.cpp
@@ -62,7 +62,13 @@ static constexpr Entry kTable[] = {
 	{0x054c, 0x0df2, "DualSense Edge"},
 };
 
-} // namespace
+} /**
+ * @brief Lookup a human-friendly name for a USB device by vendor and product ID.
+ *
+ * @param vid USB vendor ID.
+ * @param pid USB product ID.
+ * @return const char* Pointer to a null-terminated string containing the device name if a matching VID/PID is found, `nullptr` otherwise. The returned pointer refers to static storage owned by this module. 
+ */
 
 const char* GetFriendlyName(uint16_t vid, uint16_t pid)
 {

--- a/src/usb_names.h
+++ b/src/usb_names.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <cstdint>
+
+// Returns a static friendly name for known VID+PID (e.g. from usb.ids); nullptr if unknown.
+[[nodiscard]] const char* GetFriendlyName(uint16_t vid, uint16_t pid);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gamepad panels now display friendly device names next to the player number and backend, improving identification.
  * Input backends report a short backend name and per-slot device display names so the UI shows connected controller models.
  * Added a built-in USB name lookup so commonly used controllers are shown with human-friendly names in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->