### PR TITLE
Added version resource

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install vpatch
+        run: dotnet tool install --global Nefarius.Tools.Vpatch
+
+      - name: Stamp version in resource file
+        shell: pwsh
+        run: |
+          $version = "0.0.${{ github.run_number }}"
+          vpatch --stamp-version $version --target-file "res\app.rc" --resource.file-version --resource.product-version
+
       - name: Bootstrap vcpkg
         run: vcpkg/bootstrap-vcpkg.bat
 

--- a/.github/workflows/upload-build.yml
+++ b/.github/workflows/upload-build.yml
@@ -22,8 +22,16 @@ jobs:
         shell: pwsh
         run: |
           $tag = "${{ github.ref_name }}"
-          $version = if ($tag.StartsWith("v")) { $tag.Substring(1) } else { $tag }
-          vpatch --stamp-version $version --target-file "res\app.rc" --resource.file-version --resource.product-version
+          $semverPattern = '^v?(\d+)\.(\d+)\.(\d+)(?:-(.+))?$'
+          if ($tag -notmatch $semverPattern) {
+            Write-Error "Tag '$tag' does not match semantic version pattern (e.g. v1.2.3 or v1.2.3-rc1). Expected: ^v?(\d+)\.(\d+)\.(\d+)(?:-(.+))?$"
+            exit 1
+          }
+          $major = $Matches[1]
+          $minor = $Matches[2]
+          $patch = $Matches[3]
+          $versionNumeric = "$major.$minor.$patch.0"
+          vpatch --stamp-version $versionNumeric --target-file "res\app.rc" --resource.file-version --resource.product-version
 
       - name: Bootstrap vcpkg
         run: vcpkg/bootstrap-vcpkg.bat

--- a/.github/workflows/upload-build.yml
+++ b/.github/workflows/upload-build.yml
@@ -15,6 +15,16 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install vpatch
+        run: dotnet tool install --global Nefarius.Tools.Vpatch
+
+      - name: Stamp version in resource file
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $version = if ($tag.StartsWith("v")) { $tag.Substring(1) } else { $tag }
+          vpatch --stamp-version $version --target-file "res\app.rc" --resource.file-version --resource.product-version
+
       - name: Bootstrap vcpkg
         run: vcpkg/bootstrap-vcpkg.bat
 

--- a/res/app.rc
+++ b/res/app.rc
@@ -2,3 +2,29 @@
 IDI_APPICON ICON "app.ico"
 IDR_XBOX_BODY RCDATA "..\\assets\\xbox_body.png"
 IDR_DUALSENSE_BODY RCDATA "..\\assets\\dualsense_body.png"
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION 1,0,0,0
+PRODUCTVERSION 1,0,0,0
+FILEFLAGSMASK 0x3fL
+FILEFLAGS 0x0L
+FILEOS 0x40004L
+FILETYPE 0x1L
+FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileVersion", "1.0.0.0"
+            VALUE "ProductVersion", "1.0.0.0"
+            VALUE "FileDescription", "MultiPadTester - Gamepad input tester"
+            VALUE "ProductName", "MultiPadTester"
+            VALUE "OriginalFilename", "MultiPadTester.exe"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now automatically stamps build versions during the Windows build process so artifacts carry consistent version metadata.
  * Windows build outputs include a new resource version block with standard file/product version and descriptive fields.
  * Streamlines versioning and release metadata to improve traceability and consistency across builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->