### PR TITLE
Add vendor/product ID storage and gamepad device identification for WGI backend

### DIFF
--- a/src/wgi_backend.cpp
+++ b/src/wgi_backend.cpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace
 {

--- a/src/wgi_backend.cpp
+++ b/src/wgi_backend.cpp
@@ -35,6 +35,22 @@ namespace
 		if ((wgi & GamepadButtons::RightThumbstick) != GamepadButtons::None) b |= std::to_underlying(RightThumb);
 		return b;
 	}
+
+	std::string GetDisplayNameForGamepad(Gamepad const& pad, int slotIndex)
+	{
+		try
+		{
+			auto raw = RawGameController::FromGameController(pad);
+			if (raw)
+			{
+				auto name = raw.DisplayName();
+				if (!name.empty())
+					return winrt::to_string(name);
+			}
+		}
+		catch (...) {}
+		return "Gamepad " + std::to_string(slotIndex);
+	}
 }
 
 struct WgiBackend::Impl
@@ -55,7 +71,7 @@ struct WgiBackend::Impl
 			if (!slotGamepads[i])
 			{
 				slotGamepads[i] = pad;
-				slotDisplayNames[i] = "Gamepad " + std::to_string(i);
+				slotDisplayNames[i] = GetDisplayNameForGamepad(pad, i);
 				break;
 			}
 		}
@@ -102,8 +118,9 @@ void WgiBackend::Init(HWND)
 	{
 		try
 		{
-			impl_->slotGamepads[i] = gamepads.GetAt(static_cast<uint32_t>(i));
-			impl_->slotDisplayNames[i] = "Gamepad " + std::to_string(i);
+			auto pad = gamepads.GetAt(static_cast<uint32_t>(i));
+			impl_->slotGamepads[i] = pad;
+			impl_->slotDisplayNames[i] = GetDisplayNameForGamepad(pad, i);
 		}
 		catch (winrt::hresult_out_of_bounds const&)
 		{
@@ -161,7 +178,7 @@ const char* WgiBackend::GetSlotDisplayName(int slot) const
 	if (slot < 0 || slot >= kMaxSlots) return nullptr;
 	std::lock_guard lock(impl_->mutex);
 	if (!impl_->slotGamepads[slot]) return nullptr;
-	thread_local static std::string result;
-	result = impl_->slotDisplayNames[slot];
-	return result.c_str();
+	thread_local static std::array<std::string, kMaxSlots> slotResultBuffers;
+	slotResultBuffers[slot] = impl_->slotDisplayNames[slot];
+	return slotResultBuffers[slot].c_str();
 }

--- a/src/wgi_backend.cpp
+++ b/src/wgi_backend.cpp
@@ -50,7 +50,7 @@ namespace
 			}
 		}
 		catch (...) {}
-		return "Gamepad " + std::to_string(slotIndex);
+		return "Gamepad " + std::to_string(slotIndex + 1);
 	}
 
 	void GetDeviceIdsForGamepad(Gamepad const& pad, uint16_t* vendorId, uint16_t* productId)

--- a/src/wgi_backend.cpp
+++ b/src/wgi_backend.cpp
@@ -3,6 +3,7 @@
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Gaming.Input.h>
 #include <array>
+#include <cstdint>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -51,6 +52,24 @@ namespace
 		catch (...) {}
 		return "Gamepad " + std::to_string(slotIndex);
 	}
+
+	void GetDeviceIdsForGamepad(Gamepad const& pad, uint16_t* vendorId, uint16_t* productId)
+	{
+		if (!vendorId && !productId) return;
+		try
+		{
+			auto raw = RawGameController::FromGameController(pad);
+			if (raw)
+			{
+				if (vendorId) *vendorId = raw.HardwareVendorId();
+				if (productId) *productId = raw.HardwareProductId();
+				return;
+			}
+		}
+		catch (...) {}
+		if (vendorId) *vendorId = 0;
+		if (productId) *productId = 0;
+	}
 }
 
 struct WgiBackend::Impl
@@ -59,6 +78,8 @@ struct WgiBackend::Impl
 	std::array<std::optional<Gamepad>, kMaxSlots> slotGamepads{};
 	GamepadState states[kMaxSlots]{};
 	std::array<std::string, kMaxSlots> slotDisplayNames;
+	std::array<uint16_t, kMaxSlots> slotVendorIds{};
+	std::array<uint16_t, kMaxSlots> slotProductIds{};
 
 	winrt::event_token addedToken;
 	winrt::event_token removedToken;
@@ -72,6 +93,7 @@ struct WgiBackend::Impl
 			{
 				slotGamepads[i] = pad;
 				slotDisplayNames[i] = GetDisplayNameForGamepad(pad, i);
+				GetDeviceIdsForGamepad(pad, &slotVendorIds[i], &slotProductIds[i]);
 				break;
 			}
 		}
@@ -85,6 +107,8 @@ struct WgiBackend::Impl
 			if (slotGamepads[i] && slotGamepads[i] == pad)
 			{
 				slotGamepads[i].reset();
+				slotVendorIds[i] = 0;
+				slotProductIds[i] = 0;
 				break;
 			}
 		}
@@ -121,6 +145,7 @@ void WgiBackend::Init(HWND)
 			auto pad = gamepads.GetAt(static_cast<uint32_t>(i));
 			impl_->slotGamepads[i] = pad;
 			impl_->slotDisplayNames[i] = GetDisplayNameForGamepad(pad, i);
+			GetDeviceIdsForGamepad(pad, &impl_->slotVendorIds[i], &impl_->slotProductIds[i]);
 		}
 		catch (winrt::hresult_out_of_bounds const&)
 		{
@@ -181,4 +206,19 @@ const char* WgiBackend::GetSlotDisplayName(int slot) const
 	thread_local static std::array<std::string, kMaxSlots> slotResultBuffers;
 	slotResultBuffers[slot] = impl_->slotDisplayNames[slot];
 	return slotResultBuffers[slot].c_str();
+}
+
+void WgiBackend::GetSlotDeviceIds(int slot, uint16_t* vendorId, uint16_t* productId) const
+{
+	if (slot < 0 || slot >= kMaxSlots)
+	{
+		if (vendorId) *vendorId = 0;
+		if (productId) *productId = 0;
+		return;
+	}
+	std::lock_guard lock(impl_->mutex);
+	uint16_t vid = impl_->slotGamepads[slot] ? impl_->slotVendorIds[slot] : 0;
+	uint16_t pid = impl_->slotGamepads[slot] ? impl_->slotProductIds[slot] : 0;
+	if (vendorId) *vendorId = vid;
+	if (productId) *productId = pid;
 }

--- a/src/wgi_backend.cpp
+++ b/src/wgi_backend.cpp
@@ -16,6 +16,12 @@ namespace
 
 	constexpr int kMaxSlots = 4;
 
+	/**
+	 * @brief Converts a WinRT GamepadButtons bitmask into the internal 16-bit button mask.
+	 *
+	 * @param wgi Bitfield of WinRT GamepadButtons flags to map.
+	 * @return uint16_t Bitmask where each set bit corresponds to the internal Button enum value for a pressed button.
+	 */
 	uint16_t MapGamepadButtons(GamepadButtons wgi)
 	{
 		uint16_t b = 0;
@@ -37,6 +43,17 @@ namespace
 		return b;
 	}
 
+	/**
+	 * @brief Obtains a human-friendly display name for a gamepad, falling back to a numbered default.
+	 *
+	 * Attempts to retrieve the controller's DisplayName from its RawGameController representation.
+	 * If a display name is unavailable or retrieval fails, returns "Gamepad N" where N is
+	 * slotIndex + 1.
+	 *
+	 * @param pad WinRT Gamepad instance to query.
+	 * @param slotIndex Zero-based slot index used to generate the fallback name.
+	 * @return std::string The resolved display name or a fallback like "Gamepad 1".
+	 */
 	std::string GetDisplayNameForGamepad(Gamepad const& pad, int slotIndex)
 	{
 		try
@@ -53,6 +70,18 @@ namespace
 		return "Gamepad " + std::to_string(slotIndex + 1);
 	}
 
+	/**
+	 * @brief Retrieve the hardware vendor and product IDs for a gamepad.
+	 *
+	 * Attempts to obtain the controller's hardware vendor and product identifiers
+	 * and writes them to the provided pointers. If retrieval fails or the
+	 * identifiers are unavailable, writes 0 to the corresponding outputs.
+	 * If both output pointers are null, the function does nothing.
+	 *
+	 * @param pad The gamepad to query.
+	 * @param vendorId Pointer to receive the vendor ID, or nullptr to skip.
+	 * @param productId Pointer to receive the product ID, or nullptr to skip.
+	 */
 	void GetDeviceIdsForGamepad(Gamepad const& pad, uint16_t* vendorId, uint16_t* productId)
 	{
 		if (!vendorId && !productId) return;
@@ -84,6 +113,14 @@ struct WgiBackend::Impl
 	winrt::event_token addedToken;
 	winrt::event_token removedToken;
 
+	/**
+	 * @brief Assigns a newly connected gamepad to the first available backend slot and records its metadata.
+	 *
+	 * If a free slot exists, stores the provided gamepad handle in that slot and populates the slot's
+	 * display name and vendor/product IDs. If all slots are occupied, the added gamepad is ignored.
+	 *
+	 * @param pad The gamepad that was added.
+	 */
 	void OnGamepadAdded(IInspectable const&, Gamepad const& pad)
 	{
 		std::lock_guard lock(mutex);
@@ -99,6 +136,14 @@ struct WgiBackend::Impl
 		}
 	}
 
+	/**
+	 * @brief Handles a gamepad removal event by clearing the corresponding slot.
+	 *
+	 * Searches the tracked slots for the given gamepad handle; when a match is found,
+	 * removes the stored handle and resets the slot's vendor and product IDs to zero.
+	 *
+	 * @param pad The gamepad that was removed.
+	 */
 	void OnGamepadRemoved(IInspectable const&, Gamepad const& pad)
 	{
 		std::lock_guard lock(mutex);
@@ -126,6 +171,13 @@ WgiBackend::~WgiBackend()
 	}
 }
 
+/**
+ * @brief Initialize the WinRT gamepad backend, enumerate currently connected gamepads, and subscribe to add/remove events.
+ *
+ * Initializes the WinRT apartment once per thread, acquires the internal mutex, populates up to kMaxSlots with already-connected gamepads (storing each slot's handle, display name, and vendor/product IDs), and registers handlers for future GamepadAdded and GamepadRemoved events, saving their subscription tokens.
+ *
+ * @param hwnd Window handle provided for initialization context; currently accepted for API compatibility and not otherwise used.
+ */
 void WgiBackend::Init(HWND)
 {
 	thread_local static bool winrtInitialized = false;
@@ -198,6 +250,12 @@ const GamepadState& WgiBackend::GetState(int slot) const
 
 const char* WgiBackend::GetName() const { return Name; }
 
+/**
+ * @brief Retrieves the human-readable display name for a gamepad slot.
+ *
+ * @param slot Zero-based slot index.
+ * @return const char* Pointer to a null-terminated C string containing the display name for the given slot, or `nullptr` if the slot index is out of range or no gamepad is present in that slot. The returned pointer is valid until the next call to GetSlotDisplayName on the same thread.
+ */
 const char* WgiBackend::GetSlotDisplayName(int slot) const
 {
 	if (slot < 0 || slot >= kMaxSlots) return nullptr;
@@ -208,6 +266,15 @@ const char* WgiBackend::GetSlotDisplayName(int slot) const
 	return slotResultBuffers[slot].c_str();
 }
 
+/**
+ * @brief Retrieve the vendor and product identifiers for a slot's gamepad.
+ *
+ * Writes the 16-bit vendor and product IDs for the gamepad in the given slot into the provided output pointers. If the slot index is out of range or no gamepad is present in that slot, `0` is written for each ID. Passing a `nullptr` for either output pointer suppresses writing that value.
+ *
+ * @param slot Slot index (0 .. kMaxSlots - 1) to query.
+ * @param vendorId Pointer that receives the vendor ID, or `nullptr` to ignore.
+ * @param productId Pointer that receives the product ID, or `nullptr` to ignore.
+ */
 void WgiBackend::GetSlotDeviceIds(int slot, uint16_t* vendorId, uint16_t* productId) const
 {
 	if (slot < 0 || slot >= kMaxSlots)

--- a/src/wgi_backend.h
+++ b/src/wgi_backend.h
@@ -17,6 +17,7 @@ public:
 	[[nodiscard]] const GamepadState& GetState(int slot) const override;
 	[[nodiscard]] const char* GetName() const override;
 	[[nodiscard]] const char* GetSlotDisplayName(int slot) const override;
+	void GetSlotDeviceIds(int slot, uint16_t* vendorId, uint16_t* productId) const override;
 
 private:
 	struct Impl;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-gamepad device identification retrieval added so vendor and product IDs can be obtained for connected gamepads.
  * Improved display name resolution for clearer device labeling.

* **Improvements**
  * Initialization now enumerates existing gamepads and populates display names and IDs.
  * Per-slot name handling made safer and more reliable.

* **Bug Fixes**
  * Slots and device IDs are properly cleared when gamepads disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->