### PR TITLE
Added libwdi detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It polls multiple input APIs in parallel and renders one live gamepad view per d
 - Windows only. Linux and macOS are not supported.
 - The GameInput tab is available only when the [GameInput redistributable](https://github.com/microsoftconnect/GameInput/releases) is installed.
 - On startup, MultiPad Tester checks for HidHide. If HidHide is currently enabled, the app shows a warning because hidden devices can make the results less accurate. If another HidHide app is already open, you may see a different warning asking you to close those apps and restart MultiPad Tester for the best results.
+- If any **Universal Serial Bus devices** (setup class `USBDevice`) use a **Zadig / libwdi** driver (`Provider: libwdi`), the app shows a warning listing those device instance IDs. Those devices are not discoverable through normal gamepad APIs until the original driver stack is restored.
 - Backend results are expected to differ by API design (device class support, mapping behavior, and feature exposure).
 - This tool is for input inspection and diagnostics; it does not provide remapping, virtualization, or driver installation.
 

--- a/src/libwdi_probe.cpp
+++ b/src/libwdi_probe.cpp
@@ -10,10 +10,43 @@
 #include <array>
 #include <cwctype>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace
 {
+	std::wstring FormatProbeFailure(const std::wstring_view context, const DWORD err)
+	{
+		wchar_t* sysBuf = nullptr;
+		const DWORD n = FormatMessageW(
+			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			nullptr,
+			err,
+			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+			reinterpret_cast<LPWSTR>(&sysBuf),
+			0,
+			nullptr);
+		std::wstring msg;
+		msg.reserve(context.size() + 64 + (n ? n : 0));
+		msg.append(context);
+		msg.append(L" (Win32 error ");
+		msg.append(std::to_wstring(err));
+		msg.append(L")");
+		if (n != 0 && sysBuf != nullptr)
+		{
+			msg.append(L": ");
+			msg.append(sysBuf, n);
+			LocalFree(sysBuf);
+			while (!msg.empty() && (msg.back() == L'\r' || msg.back() == L'\n'))
+				msg.pop_back();
+		}
+		else if (sysBuf != nullptr)
+		{
+			LocalFree(sysBuf);
+		}
+		return msg;
+	}
+
 	// "USBDevice" — Universal Serial Bus devices (WinUSB, Zadig, etc.)
 	// https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors
 	const GUID kGuidDevClassUsbDevice = {
@@ -265,7 +298,11 @@ LibwdiUsbProbeResult ProbeLibwdiUsbDevices()
 		nullptr,
 		DIGCF_PRESENT);
 	if (devInfoSet == INVALID_HANDLE_VALUE)
+	{
+		result.succeeded = false;
+		result.errorMessage = FormatProbeFailure(L"SetupDiGetClassDevsW failed", GetLastError());
 		return result;
+	}
 
 	SP_DEVINFO_DATA devInfoData{};
 	devInfoData.cbSize = sizeof(devInfoData);
@@ -290,5 +327,7 @@ LibwdiUsbProbeResult ProbeLibwdiUsbDevices()
 	SetupDiDestroyDeviceInfoList(devInfoSet);
 
 	std::sort(result.instanceIds.begin(), result.instanceIds.end());
+	result.succeeded = true;
+	result.errorMessage.clear();
 	return result;
 }

--- a/src/libwdi_probe.cpp
+++ b/src/libwdi_probe.cpp
@@ -7,7 +7,9 @@
 #include <devpkey.h>
 
 #include <algorithm>
+#include <array>
 #include <cwctype>
+#include <string>
 #include <vector>
 
 namespace
@@ -71,6 +73,156 @@ namespace
 		out.assign(reinterpret_cast<const wchar_t*>(buf.data()));
 		return true;
 	}
+
+	std::wstring ToUpper(std::wstring s)
+	{
+		std::ranges::transform(s, s.begin(), [](const wchar_t ch) {
+			return static_cast<wchar_t>(std::towupper(static_cast<wint_t>(ch)));
+		});
+		return s;
+	}
+
+	bool ReadRegistryStringProperty(
+		HDEVINFO devInfoSet,
+		SP_DEVINFO_DATA& devInfoData,
+		DWORD prop,
+		std::wstring& out)
+	{
+		out.clear();
+		DWORD regType = 0;
+		DWORD required = 0;
+		if (!SetupDiGetDeviceRegistryPropertyW(
+			    devInfoSet,
+			    &devInfoData,
+			    prop,
+			    &regType,
+			    nullptr,
+			    0,
+			    &required))
+		{
+			if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || required == 0)
+				return false;
+		}
+
+		std::vector<BYTE> buf(required);
+		if (!SetupDiGetDeviceRegistryPropertyW(
+			    devInfoSet,
+			    &devInfoData,
+			    prop,
+			    &regType,
+			    buf.data(),
+			    required,
+			    &required))
+			return false;
+		if (regType != REG_SZ && regType != REG_EXPAND_SZ)
+			return false;
+		out.assign(reinterpret_cast<const wchar_t*>(buf.data()));
+		return true;
+	}
+
+	bool ReadRegistryMultiSzProperty(
+		HDEVINFO devInfoSet,
+		SP_DEVINFO_DATA& devInfoData,
+		DWORD prop,
+		std::vector<std::wstring>& out)
+	{
+		out.clear();
+		DWORD regType = 0;
+		DWORD required = 0;
+		if (!SetupDiGetDeviceRegistryPropertyW(
+			    devInfoSet,
+			    &devInfoData,
+			    prop,
+			    &regType,
+			    nullptr,
+			    0,
+			    &required))
+		{
+			if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || required == 0)
+				return false;
+		}
+
+		std::vector<BYTE> buf(required);
+		if (!SetupDiGetDeviceRegistryPropertyW(
+			    devInfoSet,
+			    &devInfoData,
+			    prop,
+			    &regType,
+			    buf.data(),
+			    required,
+			    &required))
+			return false;
+		if (regType != REG_MULTI_SZ)
+			return false;
+
+		const auto* p = reinterpret_cast<const wchar_t*>(buf.data());
+		while (*p != L'\0')
+		{
+			out.emplace_back(p);
+			p += out.back().size() + 1;
+		}
+		return !out.empty();
+	}
+
+	bool LooksLikeControllerName(const std::wstring& name)
+	{
+		if (name.empty())
+			return false;
+		const std::wstring upper = ToUpper(name);
+		constexpr std::array controllerKeywords{
+			L"CONTROLLER",
+			L"GAMEPAD",
+			L"JOYSTICK",
+			L"XBOX",
+			L"DUALSENSE",
+			L"DUALSHOCK",
+			L"PLAYSTATION",
+			L"NINTENDO"
+		};
+		return std::ranges::any_of(controllerKeywords, [&](const wchar_t* keyword) {
+			return upper.find(keyword) != std::wstring::npos;
+		});
+	}
+
+	bool IsTargetController(
+		HDEVINFO devInfoSet,
+		SP_DEVINFO_DATA& devInfoData)
+	{
+		// First pass: hardware IDs should identify known controller vendors.
+		std::vector<std::wstring> hardwareIds;
+		if (ReadRegistryMultiSzProperty(devInfoSet, devInfoData, SPDRP_HARDWAREID, hardwareIds))
+		{
+			constexpr std::array controllerVendorTokens{
+				L"VID_045E", // Microsoft / Xbox
+				L"VID_054C", // Sony
+				L"VID_057E", // Nintendo
+				L"VID_28DE", // Valve
+				L"VID_0F0D", // Hori
+				L"VID_0E6F", // PDP
+				L"VID_046D"  // Logitech
+			};
+			for (const auto& id : hardwareIds)
+			{
+				const std::wstring upperId = ToUpper(id);
+				for (const wchar_t* token : controllerVendorTokens)
+				{
+					if (upperId.find(token) != std::wstring::npos)
+						return true;
+				}
+			}
+		}
+
+		// Fallback: friendly/device description keyword heuristics.
+		std::wstring name;
+		if (ReadRegistryStringProperty(devInfoSet, devInfoData, SPDRP_FRIENDLYNAME, name) &&
+		    LooksLikeControllerName(name))
+			return true;
+		if (ReadRegistryStringProperty(devInfoSet, devInfoData, SPDRP_DEVICEDESC, name) &&
+		    LooksLikeControllerName(name))
+			return true;
+
+		return false;
+	}
 }
 
 LibwdiUsbProbeResult ProbeLibwdiUsbDevices()
@@ -94,6 +246,8 @@ LibwdiUsbProbeResult ProbeLibwdiUsbDevices()
 		if (!ReadProviderString(devInfoSet, devInfoData, provider))
 			continue;
 		if (!IsLibwdiProvider(provider))
+			continue;
+		if (!IsTargetController(devInfoSet, devInfoData))
 			continue;
 
 		wchar_t instanceId[MAX_DEVICE_ID_LEN]{};

--- a/src/libwdi_probe.cpp
+++ b/src/libwdi_probe.cpp
@@ -155,12 +155,42 @@ namespace
 		if (regType != REG_MULTI_SZ)
 			return false;
 
-		const auto* p = reinterpret_cast<const wchar_t*>(buf.data());
-		while (*p != L'\0')
+		if (buf.size() % sizeof(wchar_t) != 0)
+			return false;
+
+		const auto* const base = reinterpret_cast<const wchar_t*>(buf.data());
+		const auto* const end = base + (buf.size() / sizeof(wchar_t));
+
+		const wchar_t* p = base;
+		while (p < end)
 		{
-			out.emplace_back(p);
-			p += out.back().size() + 1;
+			if (*p == L'\0')
+			{
+				// Empty entry terminates the REG_MULTI_SZ list (final double-null).
+				break;
+			}
+
+			const wchar_t* term = p;
+			while (term < end && *term != L'\0')
+				++term;
+			if (term >= end)
+			{
+				out.clear();
+				return false;
+			}
+
+			const size_t len = static_cast<size_t>(term - p);
+			const wchar_t* const next = term + 1;
+			if (next > end)
+			{
+				out.clear();
+				return false;
+			}
+
+			out.emplace_back(p, len);
+			p = next;
 		}
+
 		return !out.empty();
 	}
 

--- a/src/libwdi_probe.cpp
+++ b/src/libwdi_probe.cpp
@@ -1,0 +1,110 @@
+#include "libwdi_probe.h"
+
+#include <Windows.h>
+#include <initguid.h>
+#include <SetupAPI.h>
+#include <cfgmgr32.h>
+#include <devpkey.h>
+
+#include <algorithm>
+#include <cwctype>
+#include <vector>
+
+namespace
+{
+	// "USBDevice" — Universal Serial Bus devices (WinUSB, Zadig, etc.)
+	// https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors
+	const GUID kGuidDevClassUsbDevice = {
+		0x88bae032, 0x5a81, 0x49f0, {0xbc, 0x3d, 0xa4, 0xff, 0x13, 0x82, 0x16, 0xd6}};
+
+	void TrimInPlace(std::wstring& s)
+	{
+		while (!s.empty() && std::iswspace(static_cast<wint_t>(s.front())))
+			s.erase(s.begin());
+		while (!s.empty() && std::iswspace(static_cast<wint_t>(s.back())))
+			s.pop_back();
+	}
+
+	bool IsLibwdiProvider(std::wstring provider)
+	{
+		TrimInPlace(provider);
+		return _wcsicmp(provider.c_str(), L"libwdi") == 0;
+	}
+
+	bool ReadProviderString(
+		HDEVINFO devInfoSet,
+		SP_DEVINFO_DATA& devInfoData,
+		std::wstring& out)
+	{
+		out.clear();
+
+		DEVPROPTYPE propType = 0;
+		DWORD required = 0;
+		if (!SetupDiGetDevicePropertyW(
+			    devInfoSet,
+			    &devInfoData,
+			    &DEVPKEY_Device_DriverProvider,
+			    &propType,
+			    nullptr,
+			    0,
+			    &required,
+			    0))
+		{
+			if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || required == 0)
+				return false;
+		}
+
+		std::vector<BYTE> buf(required);
+		DWORD used = required;
+		if (!SetupDiGetDevicePropertyW(
+			    devInfoSet,
+			    &devInfoData,
+			    &DEVPKEY_Device_DriverProvider,
+			    &propType,
+			    buf.data(),
+			    used,
+			    &used,
+			    0))
+			return false;
+		if (propType != DEVPROP_TYPE_STRING)
+			return false;
+		out.assign(reinterpret_cast<const wchar_t*>(buf.data()));
+		return true;
+	}
+}
+
+LibwdiUsbProbeResult ProbeLibwdiUsbDevices()
+{
+	LibwdiUsbProbeResult result;
+
+	HDEVINFO devInfoSet = SetupDiGetClassDevsW(
+		&kGuidDevClassUsbDevice,
+		nullptr,
+		nullptr,
+		DIGCF_PRESENT);
+	if (devInfoSet == INVALID_HANDLE_VALUE)
+		return result;
+
+	SP_DEVINFO_DATA devInfoData{};
+	devInfoData.cbSize = sizeof(devInfoData);
+
+	for (DWORD index = 0; SetupDiEnumDeviceInfo(devInfoSet, index, &devInfoData); ++index)
+	{
+		std::wstring provider;
+		if (!ReadProviderString(devInfoSet, devInfoData, provider))
+			continue;
+		if (!IsLibwdiProvider(provider))
+			continue;
+
+		wchar_t instanceId[MAX_DEVICE_ID_LEN]{};
+		if (!SetupDiGetDeviceInstanceIdW(devInfoSet, &devInfoData, instanceId, MAX_DEVICE_ID_LEN, nullptr))
+			continue;
+
+		result.instanceIds.emplace_back(instanceId);
+	}
+
+	SetupDiDestroyDeviceInfoList(devInfoSet);
+
+	std::sort(result.instanceIds.begin(), result.instanceIds.end());
+	return result;
+}

--- a/src/libwdi_probe.h
+++ b/src/libwdi_probe.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+/**
+ * @brief Result of scanning for USBDevice-class devices whose driver Provider is libwdi (Zadig).
+ */
+struct LibwdiUsbProbeResult
+{
+	/** Device instance IDs (PnP) for matching devices, sorted for stable UI. */
+	std::vector<std::wstring> instanceIds;
+};
+
+/**
+ * @brief Enumerate present devices in setup class USBDevice and collect those with Provider "libwdi".
+ *
+ * Uses DEVPKEY_Device_DriverProvider via SetupAPI.
+ */
+LibwdiUsbProbeResult ProbeLibwdiUsbDevices();

--- a/src/libwdi_probe.h
+++ b/src/libwdi_probe.h
@@ -8,7 +8,11 @@
  */
 struct LibwdiUsbProbeResult
 {
-	/** Device instance IDs (PnP) for matching devices, sorted for stable UI. */
+	/** False if enumeration or required queries failed; true if the scan completed (instanceIds may still be empty). */
+	bool succeeded = false;
+	/** Present when succeeded is false; describes the failure (e.g. Setup API error). */
+	std::wstring errorMessage;
+	/** Device instance IDs (PnP) for matching devices, sorted for stable UI. Valid only when succeeded is true. */
 	std::vector<std::wstring> instanceIds;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@
 #include "sony_layout.h"
 #include "texture_loader.h"
 #include "hidhide_probe.h"
+#include "libwdi_probe.h"
 #include "resource.h"
 
 #define IDM_ABOUT 0xF200
@@ -224,7 +225,37 @@ static bool g_showAbout = false;
 static bool g_showPreferences = false;
 static bool g_showHidHideWarning = false;
 static bool g_showHidHideBlockedWarning = false;
+static bool g_showLibwdiUsbWarning = false;
+static std::vector<std::string> g_libwdiUsbInstanceIdsUtf8;
 static AppPrefs g_prefs;
+
+static std::string WideToUtf8(const std::wstring_view w)
+{
+	if (w.empty())
+		return {};
+	const int n = WideCharToMultiByte(
+		CP_UTF8,
+		0,
+		w.data(),
+		static_cast<int>(w.size()),
+		nullptr,
+		0,
+		nullptr,
+		nullptr);
+	if (n <= 0)
+		return {};
+	std::string out(static_cast<size_t>(n), '\0');
+	WideCharToMultiByte(
+		CP_UTF8,
+		0,
+		w.data(),
+		static_cast<int>(w.size()),
+		out.data(),
+		n,
+		nullptr,
+		nullptr);
+	return out;
+}
 
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(
 	HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -370,6 +401,18 @@ int APIENTRY wWinMain(
 		break;
 	default:
 		break;
+	}
+
+	{
+		const LibwdiUsbProbeResult libwdiProbe = ProbeLibwdiUsbDevices();
+		if (!libwdiProbe.instanceIds.empty())
+		{
+			g_showLibwdiUsbWarning = true;
+			g_libwdiUsbInstanceIdsUtf8.clear();
+			g_libwdiUsbInstanceIdsUtf8.reserve(libwdiProbe.instanceIds.size());
+			for (const auto& id : libwdiProbe.instanceIds)
+				g_libwdiUsbInstanceIdsUtf8.push_back(WideToUtf8(id));
+		}
 	}
 
 	wil::com_ptr<ID3D11ShaderResourceView> controllerTextureXbox;
@@ -662,6 +705,47 @@ int APIENTRY wWinMain(
 				ImGui::Spacing();
 				if (ImGui::Button("OK", ImVec2(100, 0)))
 					g_showHidHideBlockedWarning = false;
+			}
+			ImGui::End();
+		}
+
+		if (g_showLibwdiUsbWarning)
+		{
+			const float warningMinW = 520.f, warningMinH = 240.f;
+			ImGui::SetNextWindowSizeConstraints(ImVec2(warningMinW, warningMinH),
+			                                    ImVec2(FLT_MAX, FLT_MAX));
+			ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(),
+			                        ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+			if (ImGui::Begin("Zadig / libwdi driver detected", &g_showLibwdiUsbWarning,
+			                 ImGuiWindowFlags_Modal | ImGuiWindowFlags_AlwaysAutoResize |
+			                     ImGuiWindowFlags_NoResize))
+			{
+				ImGui::TextWrapped(
+					"At least one device in the \"Universal Serial Bus devices\" (USBDevice) class is using a driver installed by Zadig / libwdi (Provider: libwdi).");
+				ImGui::Spacing();
+				ImGui::TextWrapped(
+					"Those devices are not discoverable by MultiPad Tester through normal gamepad/HID APIs. To have affected controllers detected again, undo the driver replacement in Device Manager (or restore the original driver stack) for those devices.");
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::TextUnformatted("Affected device instance IDs:");
+				const float listH = ImGui::GetTextLineHeightWithSpacing() * 8.0f + 8.0f;
+				ImGui::BeginChild(
+					"##LibwdiInstanceIds",
+					ImVec2(0.0f, listH),
+					true,
+					ImGuiWindowFlags_HorizontalScrollbar);
+				for (int i = 0; i < static_cast<int>(g_libwdiUsbInstanceIdsUtf8.size()); ++i)
+				{
+					ImGui::PushID(i);
+					ImGui::Bullet();
+					ImGui::SameLine();
+					ImGui::TextUnformatted(g_libwdiUsbInstanceIdsUtf8[static_cast<size_t>(i)].c_str());
+					ImGui::PopID();
+				}
+				ImGui::EndChild();
+				ImGui::Spacing();
+				if (ImGui::Button("OK", ImVec2(100, 0)))
+					g_showLibwdiUsbWarning = false;
 			}
 			ImGui::End();
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -663,50 +663,70 @@ int APIENTRY wWinMain(
 			ImGui::End();
 		}
 
+		const char* const kHidHideActivePopupId = "HidHide Active Warning";
 		if (g_showHidHideWarning)
+			ImGui::OpenPopup(kHidHideActivePopupId);
+
+		const bool hidHideActivePopupActive =
+			g_showHidHideWarning || ImGui::IsPopupOpen(kHidHideActivePopupId, ImGuiPopupFlags_None);
+		if (hidHideActivePopupActive)
 		{
 			const float warningMinW = 460.f, warningMinH = 170.f;
 			ImGui::SetNextWindowSizeConstraints(ImVec2(warningMinW, warningMinH),
 			                                    ImVec2(FLT_MAX, FLT_MAX));
 			ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(),
 			                        ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-			if (ImGui::Begin("HidHide Active Warning", &g_showHidHideWarning,
-			                 ImGuiWindowFlags_Modal | ImGuiWindowFlags_AlwaysAutoResize |
-			                     ImGuiWindowFlags_NoResize))
+		}
+		if (ImGui::BeginPopupModal(
+			    kHidHideActivePopupId,
+			    &g_showHidHideWarning,
+			    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize))
+		{
+			ImGui::TextWrapped("HidHide is installed and currently active on this system.");
+			ImGui::Spacing();
+			ImGui::TextWrapped("When active, HidHide can hide physical controllers from applications and may skew MultiPad Tester detection and backend comparison results.");
+			ImGui::Spacing();
+			ImGui::TextWrapped("For most accurate results, disable device hiding in HidHide or uninstall HidHide before testing.");
+			ImGui::Spacing();
+			if (ImGui::Button("OK", ImVec2(100, 0)))
 			{
-				ImGui::TextWrapped("HidHide is installed and currently active on this system.");
-				ImGui::Spacing();
-				ImGui::TextWrapped("When active, HidHide can hide physical controllers from applications and may skew MultiPad Tester detection and backend comparison results.");
-				ImGui::Spacing();
-				ImGui::TextWrapped("For most accurate results, disable device hiding in HidHide or uninstall HidHide before testing.");
-				ImGui::Spacing();
-				if (ImGui::Button("OK", ImVec2(100, 0)))
-					g_showHidHideWarning = false;
+				ImGui::CloseCurrentPopup();
+				g_showHidHideWarning = false;
 			}
-			ImGui::End();
+			ImGui::EndPopup();
 		}
 
+		const char* const kHidHideBlockedPopupId = "HidHide Interface Blocked";
 		if (g_showHidHideBlockedWarning)
+			ImGui::OpenPopup(kHidHideBlockedPopupId);
+
+		const bool hidHideBlockedPopupActive =
+			g_showHidHideBlockedWarning || ImGui::IsPopupOpen(kHidHideBlockedPopupId, ImGuiPopupFlags_None);
+		if (hidHideBlockedPopupActive)
 		{
 			const float warningMinW = 500.f, warningMinH = 190.f;
 			ImGui::SetNextWindowSizeConstraints(ImVec2(warningMinW, warningMinH),
 			                                    ImVec2(FLT_MAX, FLT_MAX));
 			ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(),
 			                        ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-			if (ImGui::Begin("HidHide Interface Blocked", &g_showHidHideBlockedWarning,
-			                 ImGuiWindowFlags_Modal | ImGuiWindowFlags_AlwaysAutoResize |
-			                     ImGuiWindowFlags_NoResize))
+		}
+		if (ImGui::BeginPopupModal(
+			    kHidHideBlockedPopupId,
+			    &g_showHidHideBlockedWarning,
+			    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize))
+		{
+			ImGui::TextWrapped("HidHide appears to be installed, but its control interface is currently blocked by another process.");
+			ImGui::Spacing();
+			ImGui::TextWrapped("HidHide enforces exclusive handle access, so MultiPad Tester could not accurately query whether device hiding is active.");
+			ImGui::Spacing();
+			ImGui::TextWrapped("For accurate probing and results, close all other applications that may use HidHide (for example the HidHide configuration client) and restart MultiPad Tester.");
+			ImGui::Spacing();
+			if (ImGui::Button("OK", ImVec2(100, 0)))
 			{
-				ImGui::TextWrapped("HidHide appears to be installed, but its control interface is currently blocked by another process.");
-				ImGui::Spacing();
-				ImGui::TextWrapped("HidHide enforces exclusive handle access, so MultiPad Tester could not accurately query whether device hiding is active.");
-				ImGui::Spacing();
-				ImGui::TextWrapped("For accurate probing and results, close all other applications that may use HidHide (for example the HidHide configuration client) and restart MultiPad Tester.");
-				ImGui::Spacing();
-				if (ImGui::Button("OK", ImVec2(100, 0)))
-					g_showHidHideBlockedWarning = false;
+				ImGui::CloseCurrentPopup();
+				g_showHidHideBlockedWarning = false;
 			}
-			ImGui::End();
+			ImGui::EndPopup();
 		}
 
 		// True modal: OpenPopup + BeginPopupModal (ImGuiWindowFlags_Modal on Begin is not a real modal stack)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,6 +227,8 @@ static bool g_showHidHideWarning = false;
 static bool g_showHidHideBlockedWarning = false;
 static bool g_showLibwdiUsbWarning = false;
 static std::vector<std::string> g_libwdiUsbInstanceIdsUtf8;
+/** Non-empty if the libwdi USB probe failed (enumeration error); instance ID list is not used in that case. */
+static std::string g_libwdiUsbProbeErrorUtf8;
 static AppPrefs g_prefs;
 
 static std::string WideToUtf8(const std::wstring_view w)
@@ -405,13 +407,24 @@ int APIENTRY wWinMain(
 
 	{
 		const LibwdiUsbProbeResult libwdiProbe = ProbeLibwdiUsbDevices();
-		if (!libwdiProbe.instanceIds.empty())
+		if (!libwdiProbe.succeeded)
 		{
 			g_showLibwdiUsbWarning = true;
+			g_libwdiUsbInstanceIdsUtf8.clear();
+			g_libwdiUsbProbeErrorUtf8 = WideToUtf8(libwdiProbe.errorMessage);
+		}
+		else if (!libwdiProbe.instanceIds.empty())
+		{
+			g_showLibwdiUsbWarning = true;
+			g_libwdiUsbProbeErrorUtf8.clear();
 			g_libwdiUsbInstanceIdsUtf8.clear();
 			g_libwdiUsbInstanceIdsUtf8.reserve(libwdiProbe.instanceIds.size());
 			for (const auto& id : libwdiProbe.instanceIds)
 				g_libwdiUsbInstanceIdsUtf8.push_back(WideToUtf8(id));
+		}
+		else
+		{
+			g_libwdiUsbProbeErrorUtf8.clear();
 		}
 	}
 
@@ -749,29 +762,43 @@ int APIENTRY wWinMain(
 			    &g_showLibwdiUsbWarning,
 			    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize))
 		{
-			ImGui::TextWrapped(
-				"At least one device in the \"Universal Serial Bus devices\" (USBDevice) class is using a driver installed by Zadig / libwdi (Provider: libwdi).");
-			ImGui::Spacing();
-			ImGui::TextWrapped(
-				"Those devices are not discoverable by MultiPad Tester through normal gamepad/HID APIs. To have affected controllers detected again, undo the driver replacement in Device Manager (or restore the original driver stack) for those devices.");
-			ImGui::Spacing();
-			ImGui::Separator();
-			ImGui::TextUnformatted("Affected device instance IDs:");
-			const float listH = ImGui::GetTextLineHeightWithSpacing() * 8.0f + 8.0f;
-			ImGui::BeginChild(
-				"##LibwdiInstanceIds",
-				ImVec2(0.0f, listH),
-				true,
-				ImGuiWindowFlags_HorizontalScrollbar);
-			for (int i = 0; i < static_cast<int>(g_libwdiUsbInstanceIdsUtf8.size()); ++i)
+			if (!g_libwdiUsbProbeErrorUtf8.empty())
 			{
-				ImGui::PushID(i);
-				ImGui::Bullet();
-				ImGui::SameLine();
-				ImGui::TextUnformatted(g_libwdiUsbInstanceIdsUtf8[static_cast<size_t>(i)].c_str());
-				ImGui::PopID();
+				ImGui::TextWrapped(
+					"MultiPad Tester could not enumerate USBDevice-class devices to check for Zadig / libwdi drivers.");
+				ImGui::Spacing();
+				ImGui::TextUnformatted("Details:");
+				ImGui::Spacing();
+				ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + ImGui::GetContentRegionAvail().x);
+				ImGui::TextUnformatted(g_libwdiUsbProbeErrorUtf8.c_str());
+				ImGui::PopTextWrapPos();
 			}
-			ImGui::EndChild();
+			else
+			{
+				ImGui::TextWrapped(
+					"At least one device in the \"Universal Serial Bus devices\" (USBDevice) class is using a driver installed by Zadig / libwdi (Provider: libwdi).");
+				ImGui::Spacing();
+				ImGui::TextWrapped(
+					"Those devices are not discoverable by MultiPad Tester through normal gamepad/HID APIs. To have affected controllers detected again, undo the driver replacement in Device Manager (or restore the original driver stack) for those devices.");
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::TextUnformatted("Affected device instance IDs:");
+				const float listH = ImGui::GetTextLineHeightWithSpacing() * 8.0f + 8.0f;
+				ImGui::BeginChild(
+					"##LibwdiInstanceIds",
+					ImVec2(0.0f, listH),
+					true,
+					ImGuiWindowFlags_HorizontalScrollbar);
+				for (int i = 0; i < static_cast<int>(g_libwdiUsbInstanceIdsUtf8.size()); ++i)
+				{
+					ImGui::PushID(i);
+					ImGui::Bullet();
+					ImGui::SameLine();
+					ImGui::TextUnformatted(g_libwdiUsbInstanceIdsUtf8[static_cast<size_t>(i)].c_str());
+					ImGui::PopID();
+				}
+				ImGui::EndChild();
+			}
 			ImGui::Spacing();
 			if (ImGui::Button("OK", ImVec2(100, 0)))
 			{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -709,45 +709,56 @@ int APIENTRY wWinMain(
 			ImGui::End();
 		}
 
+		// True modal: OpenPopup + BeginPopupModal (ImGuiWindowFlags_Modal on Begin is not a real modal stack)
+		const char* const kLibwdiUsbPopupId = "Zadig / libwdi driver detected";
 		if (g_showLibwdiUsbWarning)
+			ImGui::OpenPopup(kLibwdiUsbPopupId);
+
+		const bool libwdiPopupActive =
+			g_showLibwdiUsbWarning || ImGui::IsPopupOpen(kLibwdiUsbPopupId, ImGuiPopupFlags_None);
+		if (libwdiPopupActive)
 		{
 			const float warningMinW = 520.f, warningMinH = 240.f;
 			ImGui::SetNextWindowSizeConstraints(ImVec2(warningMinW, warningMinH),
 			                                    ImVec2(FLT_MAX, FLT_MAX));
 			ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(),
 			                        ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-			if (ImGui::Begin("Zadig / libwdi driver detected", &g_showLibwdiUsbWarning,
-			                 ImGuiWindowFlags_Modal | ImGuiWindowFlags_AlwaysAutoResize |
-			                     ImGuiWindowFlags_NoResize))
+		}
+		if (ImGui::BeginPopupModal(
+			    kLibwdiUsbPopupId,
+			    &g_showLibwdiUsbWarning,
+			    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize))
+		{
+			ImGui::TextWrapped(
+				"At least one device in the \"Universal Serial Bus devices\" (USBDevice) class is using a driver installed by Zadig / libwdi (Provider: libwdi).");
+			ImGui::Spacing();
+			ImGui::TextWrapped(
+				"Those devices are not discoverable by MultiPad Tester through normal gamepad/HID APIs. To have affected controllers detected again, undo the driver replacement in Device Manager (or restore the original driver stack) for those devices.");
+			ImGui::Spacing();
+			ImGui::Separator();
+			ImGui::TextUnformatted("Affected device instance IDs:");
+			const float listH = ImGui::GetTextLineHeightWithSpacing() * 8.0f + 8.0f;
+			ImGui::BeginChild(
+				"##LibwdiInstanceIds",
+				ImVec2(0.0f, listH),
+				true,
+				ImGuiWindowFlags_HorizontalScrollbar);
+			for (int i = 0; i < static_cast<int>(g_libwdiUsbInstanceIdsUtf8.size()); ++i)
 			{
-				ImGui::TextWrapped(
-					"At least one device in the \"Universal Serial Bus devices\" (USBDevice) class is using a driver installed by Zadig / libwdi (Provider: libwdi).");
-				ImGui::Spacing();
-				ImGui::TextWrapped(
-					"Those devices are not discoverable by MultiPad Tester through normal gamepad/HID APIs. To have affected controllers detected again, undo the driver replacement in Device Manager (or restore the original driver stack) for those devices.");
-				ImGui::Spacing();
-				ImGui::Separator();
-				ImGui::TextUnformatted("Affected device instance IDs:");
-				const float listH = ImGui::GetTextLineHeightWithSpacing() * 8.0f + 8.0f;
-				ImGui::BeginChild(
-					"##LibwdiInstanceIds",
-					ImVec2(0.0f, listH),
-					true,
-					ImGuiWindowFlags_HorizontalScrollbar);
-				for (int i = 0; i < static_cast<int>(g_libwdiUsbInstanceIdsUtf8.size()); ++i)
-				{
-					ImGui::PushID(i);
-					ImGui::Bullet();
-					ImGui::SameLine();
-					ImGui::TextUnformatted(g_libwdiUsbInstanceIdsUtf8[static_cast<size_t>(i)].c_str());
-					ImGui::PopID();
-				}
-				ImGui::EndChild();
-				ImGui::Spacing();
-				if (ImGui::Button("OK", ImVec2(100, 0)))
-					g_showLibwdiUsbWarning = false;
+				ImGui::PushID(i);
+				ImGui::Bullet();
+				ImGui::SameLine();
+				ImGui::TextUnformatted(g_libwdiUsbInstanceIdsUtf8[static_cast<size_t>(i)].c_str());
+				ImGui::PopID();
 			}
-			ImGui::End();
+			ImGui::EndChild();
+			ImGui::Spacing();
+			if (ImGui::Button("OK", ImVec2(100, 0)))
+			{
+				ImGui::CloseCurrentPopup();
+				g_showLibwdiUsbWarning = false;
+			}
+			ImGui::EndPopup();
 		}
 
 		ImGui::Render();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a startup diagnostic modal that detects USB devices installed with Zadig/libwdi drivers. When present, the app shows explanatory text and a scrollable list of affected device instance IDs, informs users these devices won’t be discoverable via normal gamepad APIs until the original drivers are restored, and can be dismissed with OK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->